### PR TITLE
This image only needs 2 layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,9 @@
-
 FROM python:3.7
-
 WORKDIR /app
 
-COPY . .
-RUN ls
+COPY Pipfile* ./
 
-RUN pip install --upgrade awscli
+RUN pip install --upgrade awscli pipenv && \
+    pipenv lock --requirements | pip install -r /dev/stdin
 
-
-RUN pip install pipenv
-
-RUN cat Pipfile
-
-RUN pipenv lock --requirements > requirements.txt
-
-RUN ls
-
-RUN cat requirements.txt | echo
-
-RUN pip install -r requirements.txt
-
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+ENTRYPOINT [""] # negate upstream python entrypoint


### PR DESCRIPTION
- Avoid `COPY . .`, because that includes the `.git` directory
  - The `.git` directory changes with EVERY commit!
    - Therefore your docker layers ALWAYS break cache!

- When you just wish the upstream image didn't define an ENTRYPOINT, override it with an empty one.  Let consumers use whatever command they like.

It is unclear why our already useful `alpine-aws` image wasn't extended here, rather than the 900+MB `python:3.7`.